### PR TITLE
drivers: ipm: fix in nrfx multi instance enabling procedure

### DIFF
--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -205,7 +205,8 @@ static void vipm_nrf_##_idx##_register_callback(const struct device *dev, \
 									\
 static int vipm_nrf_##_idx##_set_enabled(const struct device *dev, int enable)\
 {									\
-	if (!IS_ENABLED(CONFIG_IPM_MSG_CH_##_idx##_RX)) {		\
+	if (!(IS_ENABLED(CONFIG_IPM_MSG_CH_##_idx##_RX) ||		\
+	      IS_ENABLED(CONFIG_IPM_MSG_CH_##_idx##_TX))) {		\
 		LOG_ERR("IPM_" #_idx " is TX message channel");		\
 		return -EINVAL;						\
 	} else if (enable) {						\


### PR DESCRIPTION
Enabling procedure of IPM in nrfx multi instance implementation verified
if given instance is configure as RX. If not it returned an error.
Configuring an instance as TX is correct and enabling procedure should
work for such configuration.

This patch allows enabling IPM channels configured as TX.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>